### PR TITLE
Zpi 28 reconstruction

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="scene-recon" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="scene-recon" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="geo" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/urban-3d-reconstruction.iml
+++ b/.idea/urban-3d-reconstruction.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="geo" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/notebooks/Examine reconstruction.ipynb
+++ b/notebooks/Examine reconstruction.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:15:21.988427Z",
+     "start_time": "2024-10-27T11:15:21.976422Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import numpy as np\n",
+    "import open3d as o3d"
+   ],
+   "id": "afcc6065a4109006",
+   "outputs": [],
+   "execution_count": 33
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:13:12.417579Z",
+     "start_time": "2024-10-27T11:13:12.385458Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "pcd = o3d.io.read_point_cloud(\"../data/small_city_road_outside-d2x/sparse/sparse.ply\")",
+   "id": "e7c5dae6d6c4f927",
+   "outputs": [],
+   "execution_count": 17
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:13:42.858100Z",
+     "start_time": "2024-10-27T11:13:42.846083Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "pcd",
+   "id": "89372133928b560a",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PointCloud with 151241 points."
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 22
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:17:00.967421Z",
+     "start_time": "2024-10-27T11:17:00.867903Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "# pcd_ww_outliers_indx = (pcd.remove_statistical_outlier(nb_neighbors=50, std_ratio=0.5))",
+   "id": "d4cf1d93e216ddde",
+   "outputs": [],
+   "execution_count": 70
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:18:48.446489Z",
+     "start_time": "2024-10-27T11:18:48.386489Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "pcd_ww_outliers_indx = pcd.remove_radius_outlier(nb_points=2, radius=0.2)",
+   "id": "b6d70a7a9794ccae",
+   "outputs": [],
+   "execution_count": 87
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:18:49.062548Z",
+     "start_time": "2024-10-27T11:18:49.039038Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "pcd_ww_outliers = pcd.select_by_index(pcd_ww_outliers_indx[1])",
+   "id": "7e08131ef5b12461",
+   "outputs": [],
+   "execution_count": 88
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:18:49.598994Z",
+     "start_time": "2024-10-27T11:18:49.580954Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "pcd_ww_outliers",
+   "id": "8f5345461e038028",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PointCloud with 125677 points."
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 89
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:18:50.287194Z",
+     "start_time": "2024-10-27T11:18:50.282195Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "points = np.asarray(pcd_ww_outliers.points)",
+   "id": "17fd6d3393e7c61",
+   "outputs": [],
+   "execution_count": 90
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:18:50.988226Z",
+     "start_time": "2024-10-27T11:18:50.971198Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "np.max(points, axis=0), np.min(points, axis=0)",
+   "id": "31ef950772d44bb9",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([0.16006318, 0.19330901, 0.37243918]),\n",
+       " array([-0.22374588, -0.18138918, -0.00429772]))"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 91
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:19:02.537369Z",
+     "start_time": "2024-10-27T11:18:54.342504Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "o3d.visualization.draw_geometries([pcd_ww_outliers])",
+   "id": "8d7870af37ec5a8a",
+   "outputs": [],
+   "execution_count": 92
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-27T11:19:32.004303Z",
+     "start_time": "2024-10-27T11:19:31.974308Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "o3d.io.write_point_cloud(\"../data/small_city_road_outside-d2x/sparse/filtered_sparse.ply\", pcd_ww_outliers)",
+   "id": "14e3861a19cd1312",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 93
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/colmap_reconstruction.py
+++ b/scripts/colmap_reconstruction.py
@@ -5,25 +5,41 @@ from pathlib import Path
 
 def run_reconstruction(input_images_path, output_path, database_path, camera_model='SIMPLE_PINHOLE'):
     os.makedirs(output_path, exist_ok=True)
-    ba_global_images_ratio = 1.1
-    ba_global_images_freq = 500
-    ba_global_max_refinement_change = 0.0005
-    ba_global_max_refinements = 5
-    ba_global_points_freq = 250000
-    ba_global_points_ratio = 1.1
-    ba_local_max_refinement_change = 0.001
+
+    ba_global_function_tolerance= 0.0   # 0.0
+    ba_local_function_tolerance= 0.0    # 0.0
+
+    ba_global_images_ratio = 2.2   # 1.1
+    ba_global_images_freq = 1000   # 500
+
+    ba_global_max_refinement_change = 0.02  # 0.0005
+    ba_global_max_refinements = 3  # 5
+
+    ba_global_points_freq = 500000      # 250000
+    ba_global_points_ratio = 2.2        # 1.1
+
+    ba_local_max_refinement_change = 0.01  # 0.001
+    ba_local_max_refinements=2      # 2
+
     incremental_pipeline_options = pycolmap.IncrementalPipelineOptions(
         ba_global_images_ratio=ba_global_images_ratio,
         ba_global_images_freq=ba_global_images_freq,
+        ba_global_function_tolerance=ba_global_function_tolerance,
+        ba_local_function_tolerance=ba_local_function_tolerance,
         ba_global_max_refinement_change=ba_global_max_refinement_change,
         ba_global_max_refinements=ba_global_max_refinements,
         ba_global_points_ratio=ba_global_points_ratio,
         ba_global_points_freq=ba_global_points_freq,
         ba_local_max_refinement_change=ba_local_max_refinement_change,
+        ba_local_max_refinements=ba_local_max_refinements
     )
+    print(incremental_pipeline_options)
     if not os.path.exists(output_path / '0'):
-        pycolmap.extract_features(database_path, input_images_path, camera_model=camera_model)
-        pycolmap.match_exhaustive(database_path)
+
+        if not os.path.exists(database_path):
+            pycolmap.extract_features(database_path, input_images_path, camera_model=camera_model)
+            pycolmap.match_exhaustive(database_path)
+
         maps = pycolmap.incremental_mapping(database_path, input_images_path, output_path,
                                             options=incremental_pipeline_options)
         maps[0].write(output_path)

--- a/scripts/colmap_reconstruction.py
+++ b/scripts/colmap_reconstruction.py
@@ -5,10 +5,27 @@ from pathlib import Path
 
 def run_reconstruction(input_images_path, output_path, database_path, camera_model='SIMPLE_PINHOLE'):
     os.makedirs(output_path, exist_ok=True)
+    ba_global_images_ratio = 1.1
+    ba_global_images_freq = 500
+    ba_global_max_refinement_change = 0.0005
+    ba_global_max_refinements = 5
+    ba_global_points_freq = 250000
+    ba_global_points_ratio = 1.1
+    ba_local_max_refinement_change = 0.001
+    incremental_pipeline_options = pycolmap.IncrementalPipelineOptions(
+        ba_global_images_ratio=ba_global_images_ratio,
+        ba_global_images_freq=ba_global_images_freq,
+        ba_global_max_refinement_change=ba_global_max_refinement_change,
+        ba_global_max_refinements=ba_global_max_refinements,
+        ba_global_points_ratio=ba_global_points_ratio,
+        ba_global_points_freq=ba_global_points_freq,
+        ba_local_max_refinement_change=ba_local_max_refinement_change,
+    )
     if not os.path.exists(output_path / '0'):
         pycolmap.extract_features(database_path, input_images_path, camera_model=camera_model)
         pycolmap.match_exhaustive(database_path)
-        maps = pycolmap.incremental_mapping(database_path, input_images_path, output_path)
+        maps = pycolmap.incremental_mapping(database_path, input_images_path, output_path,
+                                            options=incremental_pipeline_options)
         maps[0].write(output_path)
         undistorted_path = output_path / 'undistorted_images'
         pycolmap.undistort_images(output_path=str(undistorted_path), 

--- a/scripts/undisort_images.py
+++ b/scripts/undisort_images.py
@@ -1,0 +1,10 @@
+import pycolmap
+recon_id = 1
+
+input_dir = f"../data/small_city_road_outside-d2x/sparse/{recon_id}"
+input_images_path = "../data/small_city_road_outside-d2x/images"
+output_dir = f"../data/small_city_road_outside-d2x/sparse/undistorted_images_{recon_id}"
+
+pycolmap.undistort_images(output_path=output_dir,
+                                  image_path=input_images_path, input_path=input_dir)
+


### PR DESCRIPTION
Changes:

1.  Add pipeline arguments - adjusting them may speed up reconstruction 
2.  Add check that if the db exists, then we assume that all features were matched and go straight away to incremental mapping
3.  Image distortion script

Suggestion:
During mapping colmap can create multiple models : we could change the script "colmap_reconstruction.py" to undisort all models (now we only do that to '0' model but the rest can be also useful). 

+ removing outliers from reconstruction 